### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
 npm run build && git add dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github-action-github-action-notify-twitter",
+  "name": "github-action-notify-twitter",
   "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-action-github-action-notify-twitter",
+      "name": "github-action-notify-twitter",
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
@@ -11076,7 +11076,7 @@
     "actions-toolkit": {
       "version": "git+ssh://git@github.com/nearform/actions-toolkit.git#42bc8890ee2df7d10db5cc8a7301ab03fc6c301b",
       "integrity": "sha512-aqoQ04EabVASf094ipfKyN8xUsxe6cWZrjbzzgFIEkS5cTUaumxwXyvQ3kuaV4lHQbijBQ9drJEI3P9RJ4DNHQ==",
-      "from": "actions-toolkit@github:nearform/actions-toolkit#42bc8890ee2df7d10db5cc8a7301ab03fc6c301b",
+      "from": "actions-toolkit@github:nearform/actions-toolkit",
       "requires": {
         "@actions/core": "^1.10.1"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "jest",
-    "prepare": "husky install",
+    "prepare": "husky",
     "build": "ncc build src --license licenses.txt"
   },
   "repository": {


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)