### PR TITLE
fix(logging): stringify err.data objects

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4965,6 +4965,193 @@ exports.debug = debug; // for test
 
 /***/ }),
 
+/***/ 3443:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.TwitterAdsSandbox = void 0;
+const globals_1 = __nccwpck_require__(7511);
+const client_ads_sandbox_write_1 = __importDefault(__nccwpck_require__(6602));
+/**
+ * Twitter ads sandbox client with all rights (read/write)
+ */
+class TwitterAdsSandbox extends client_ads_sandbox_write_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_SANDBOX_PREFIX;
+    }
+    /**
+     * Get a client with read/write rights.
+     */
+    get readWrite() {
+        return this;
+    }
+}
+exports.TwitterAdsSandbox = TwitterAdsSandbox;
+exports["default"] = TwitterAdsSandbox;
+
+
+/***/ }),
+
+/***/ 489:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const client_subclient_1 = __importDefault(__nccwpck_require__(2827));
+const globals_1 = __nccwpck_require__(7511);
+/**
+ * Base Twitter ads sandbox client with only read rights.
+ */
+class TwitterAdsSandboxReadOnly extends client_subclient_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_SANDBOX_PREFIX;
+    }
+}
+exports["default"] = TwitterAdsSandboxReadOnly;
+
+
+/***/ }),
+
+/***/ 6602:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const globals_1 = __nccwpck_require__(7511);
+const client_ads_sandbox_read_1 = __importDefault(__nccwpck_require__(489));
+/**
+ * Base Twitter ads sandbox client with read/write rights.
+ */
+class TwitterAdsSandboxReadWrite extends client_ads_sandbox_read_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_SANDBOX_PREFIX;
+    }
+    /**
+     * Get a client with only read rights.
+     */
+    get readOnly() {
+        return this;
+    }
+}
+exports["default"] = TwitterAdsSandboxReadWrite;
+
+
+/***/ }),
+
+/***/ 1767:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.TwitterAds = void 0;
+const globals_1 = __nccwpck_require__(7511);
+const client_ads_write_1 = __importDefault(__nccwpck_require__(1150));
+const client_ads_sandbox_1 = __importDefault(__nccwpck_require__(3443));
+/**
+ * Twitter ads client with all rights (read/write)
+ */
+class TwitterAds extends client_ads_write_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_PREFIX;
+    }
+    /**
+     * Get a client with read/write rights.
+     */
+    get readWrite() {
+        return this;
+    }
+    /**
+     * Get Twitter Ads Sandbox API client
+     */
+    get sandbox() {
+        if (this._sandbox)
+            return this._sandbox;
+        return this._sandbox = new client_ads_sandbox_1.default(this);
+    }
+}
+exports.TwitterAds = TwitterAds;
+exports["default"] = TwitterAds;
+
+
+/***/ }),
+
+/***/ 6541:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const client_subclient_1 = __importDefault(__nccwpck_require__(2827));
+const globals_1 = __nccwpck_require__(7511);
+/**
+ * Base Twitter ads client with only read rights.
+ */
+class TwitterAdsReadOnly extends client_subclient_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_PREFIX;
+    }
+}
+exports["default"] = TwitterAdsReadOnly;
+
+
+/***/ }),
+
+/***/ 1150:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const globals_1 = __nccwpck_require__(7511);
+const client_ads_read_1 = __importDefault(__nccwpck_require__(6541));
+/**
+ * Base Twitter ads client with read/write rights.
+ */
+class TwitterAdsReadWrite extends client_ads_read_1.default {
+    constructor() {
+        super(...arguments);
+        this._prefix = globals_1.API_ADS_PREFIX;
+    }
+    /**
+     * Get a client with only read rights.
+     */
+    get readOnly() {
+        return this;
+    }
+}
+exports["default"] = TwitterAdsReadWrite;
+
+
+/***/ }),
+
 /***/ 3335:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -5413,7 +5600,7 @@ class RequestHandlerHelper {
         let errorString = `Request failed with code ${code}`;
         if ((_a = data === null || data === void 0 ? void 0 : data.errors) === null || _a === void 0 ? void 0 : _a.length) {
             const errors = data.errors;
-            if ('code' in errors[0]) {
+            if (typeof errors[0] === 'object' && 'code' in errors[0]) {
                 errorString += ' - ' + this.formatV1Errors(errors);
             }
             else {
@@ -6448,6 +6635,7 @@ exports.TwitterApiReadOnly = exports.TwitterApiReadWrite = exports.TwitterApi = 
 const client_v1_1 = __importDefault(__nccwpck_require__(147));
 const client_v2_1 = __importDefault(__nccwpck_require__(6203));
 const readwrite_1 = __importDefault(__nccwpck_require__(4796));
+const client_ads_1 = __importDefault(__nccwpck_require__(1767));
 // "Real" exported client for usage of TwitterApi.
 /**
  * Twitter v1.1 and v2 API client.
@@ -6469,6 +6657,14 @@ class TwitterApi extends readwrite_1.default {
      */
     get readWrite() {
         return this;
+    }
+    /**
+     * Get Twitter Ads API client
+     */
+    get ads() {
+        if (this._ads)
+            return this._ads;
+        return this._ads = new client_ads_1.default(this);
     }
     /* Static helpers */
     static getErrors(error) {
@@ -6871,12 +7067,14 @@ exports["default"] = TwitterApiReadWrite;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.API_V1_1_STREAM_PREFIX = exports.API_V1_1_UPLOAD_PREFIX = exports.API_V1_1_PREFIX = exports.API_V2_LABS_PREFIX = exports.API_V2_PREFIX = void 0;
+exports.API_ADS_SANDBOX_PREFIX = exports.API_ADS_PREFIX = exports.API_V1_1_STREAM_PREFIX = exports.API_V1_1_UPLOAD_PREFIX = exports.API_V1_1_PREFIX = exports.API_V2_LABS_PREFIX = exports.API_V2_PREFIX = void 0;
 exports.API_V2_PREFIX = 'https://api.x.com/2/';
 exports.API_V2_LABS_PREFIX = 'https://api.x.com/labs/2/';
 exports.API_V1_1_PREFIX = 'https://api.x.com/1.1/';
 exports.API_V1_1_UPLOAD_PREFIX = 'https://upload.x.com/1.1/';
 exports.API_V1_1_STREAM_PREFIX = 'https://stream.x.com/1.1/';
+exports.API_ADS_PREFIX = 'https://ads-api.x.com/12/';
+exports.API_ADS_SANDBOX_PREFIX = 'https://ads-api-sandbox.twitter.com/12/';
 
 
 /***/ }),
@@ -9307,6 +9505,16 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
+/***/ 306:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+
+/***/ }),
+
 /***/ 258:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -9333,6 +9541,7 @@ __exportStar(__nccwpck_require__(8176), exports);
 __exportStar(__nccwpck_require__(9502), exports);
 __exportStar(__nccwpck_require__(4482), exports);
 __exportStar(__nccwpck_require__(531), exports);
+__exportStar(__nccwpck_require__(306), exports);
 
 
 /***/ }),
@@ -11669,6 +11878,29 @@ class TwitterApiv2ReadOnly extends client_subclient_1.default {
             .filter(line => line)
             .map(line => JSON.parse(line));
     }
+    /* Usage */
+    /**
+     * Allows you to retrieve your project usage.
+     *
+     * https://developer.x.com/en/docs/x-api/usage/tweets/introduction
+     */
+    async usage(options = {}) {
+        return this.get('usage/tweets', options);
+    }
+    /**
+     * Returns a variety of information about a single Community specified by ID.
+     * https://docs.x.com/x-api/communities/communities-lookup-by-community-id
+     */
+    community(communityId, options = {}) {
+        return this.get('communities/:id', options, { params: { id: communityId } });
+    }
+    /**
+     * Search for Communities based on keywords.
+     * https://docs.x.com/x-api/communities/search-communities
+     */
+    searchCommunities(query, options = {}) {
+        return this.get('communities/search', { query, ...options });
+    }
 }
 exports["default"] = TwitterApiv2ReadOnly;
 
@@ -11768,6 +12000,88 @@ class TwitterApiv2ReadWrite extends client_v2_read_1.default {
             payload = { text: status, ...payload };
         }
         return this.post('tweets', payload);
+    }
+    /**
+     * Uploads media to Twitter using chunked upload.
+     * https://docs.x.com/x-api/media/media-upload
+     *
+     * @param media The media buffer to upload
+     * @param options Upload options including media type and category, and additional owners
+     * @param chunkSize Size of each chunk in bytes (default: 1MB)
+     * @returns The media ID of the uploaded media
+     */
+    async uploadMedia(media, options, chunkSize = 1024 * 1024) {
+        let media_category = options.media_category;
+        // If no media category is provided, try to infer it from the media type
+        if (!options.media_category) {
+            if (options.media_type.includes('gif')) {
+                media_category = 'tweet_gif';
+            }
+            else if (options.media_type.includes('image')) {
+                media_category = 'tweet_image';
+            }
+            else if (options.media_type.includes('video')) {
+                media_category = 'tweet_video';
+            }
+        }
+        const initArguments = {
+            additional_owners: options.additional_owners,
+            media_type: options.media_type,
+            total_bytes: media.length,
+            media_category,
+        };
+        const initResponse = await this.post('media/upload/initialize', initArguments);
+        const mediaId = initResponse.data.id;
+        const chunksCount = Math.ceil(media.length / chunkSize);
+        const mediaArray = new Uint8Array(media);
+        for (let i = 0; i < chunksCount; i++) {
+            const start = i * chunkSize;
+            const end = Math.min(start + chunkSize, media.length);
+            const mediaChunk = mediaArray.slice(start, end);
+            const chunkedBuffer = Buffer.from(mediaChunk);
+            const appendArguments = {
+                segment_index: i,
+                media: chunkedBuffer,
+            };
+            await this.post(`media/upload/${mediaId}/append`, appendArguments, { forceBodyMode: 'form-data' });
+        }
+        const finalizeResponse = await this.post(`media/upload/${mediaId}/finalize`);
+        if (finalizeResponse.data.processing_info) {
+            await this.waitForMediaProcessing(mediaId);
+        }
+        return mediaId;
+    }
+    async waitForMediaProcessing(mediaId) {
+        var _a;
+        const response = await this.get('media/upload', {
+            command: 'STATUS',
+            media_id: mediaId,
+        });
+        const info = response.data.processing_info;
+        if (!info)
+            return;
+        switch (info.state) {
+            case 'succeeded':
+                return;
+            case 'failed':
+                throw new Error(`Media processing failed: ${(_a = info.error) === null || _a === void 0 ? void 0 : _a.message}`);
+            case 'pending':
+            case 'in_progress': {
+                const waitTime = info === null || info === void 0 ? void 0 : info.check_after_secs;
+                if (waitTime && waitTime > 0) {
+                    await new Promise(resolve => setTimeout(resolve, waitTime * 1000));
+                    await this.waitForMediaProcessing(mediaId);
+                }
+            }
+        }
+    }
+    /**
+     * Creates the metadata for media to be uploaded.
+     * This feature is currently only supported for images and GIFs.
+     * https://docs.x.com/x-api/media/metadata-create
+     */
+    createMediaMetadata(mediaId, metadata) {
+        return this.post('media/metadata', { id: mediaId, metadata });
     }
     /**
      * Reply to a Tweet on behalf of an authenticated user.
@@ -17549,7 +17863,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(8915)
-const { stringify, getHeadersList } = __nccwpck_require__(3834)
+const { stringify } = __nccwpck_require__(3834)
 const { webidl } = __nccwpck_require__(4222)
 const { Headers } = __nccwpck_require__(6349)
 
@@ -17625,14 +17939,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**
@@ -18060,14 +18373,15 @@ module.exports = {
 /***/ }),
 
 /***/ 3834:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ ((module) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(2613)
-const { kHeadersList } = __nccwpck_require__(6443)
-
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -18328,31 +18642,13 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  if (headers[kHeadersList]) {
-    return headers[kHeadersList]
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
-  stringify,
-  getHeadersList
+  validateCookieName,
+  validateCookiePath,
+  validateCookieValue,
+  toIMFDate,
+  stringify
 }
 
 
@@ -20281,6 +20577,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(8253)
 const { File: UndiciFile } = __nccwpck_require__(3041)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(4322)
 
+let random
+try {
+  const crypto = __nccwpck_require__(7598)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -20366,7 +20670,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -22348,6 +22652,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(5523)
+const util = __nccwpck_require__(9023)
 const { webidl } = __nccwpck_require__(4222)
 const assert = __nccwpck_require__(2613)
 
@@ -22901,6 +23206,9 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
+  },
+  [util.inspect.custom]: {
+    enumerable: false
   }
 })
 
@@ -32077,6 +32385,20 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
+
+    this.on('connectionError', (origin, targets, error) => {
+      // If a connection error occurs, we remove the client from the pool,
+      // and emit a connectionError event. They will not be re-used.
+      // Fixes https://github.com/nodejs/undici/issues/3895
+      for (const target of targets) {
+        // Do not use kRemoveClient here, as it will close the client,
+        // but the client cannot be closed in this state.
+        const idx = this[kClients].indexOf(target)
+        if (idx !== -1) {
+          this[kClients].splice(idx, 1)
+        }
+      }
+    })
   }
 
   [kGetDispatcher] () {
@@ -34485,6 +34807,14 @@ module.exports = require("net");
 
 /***/ }),
 
+/***/ 7598:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
+
+/***/ }),
+
 /***/ 8474:
 /***/ ((module) => {
 
@@ -34726,7 +35056,11 @@ async function run() {
       tweetOpts.media = { media_ids }
     }
   } catch (err) {
-    action_core.setFailed(`Action failed with error. ${err} ${err.data ?? ''}`.trim())
+    action_core.setFailed(
+      `Action failed with error. ${err} ${
+        JSON.stringify(err.data) ?? ''
+      }`.trim()
+    )
     action_core.info(`
       *** ACTION RUN - END ***
       `)
@@ -34737,7 +35071,11 @@ async function run() {
     action_core.info(`Twitter message: ${message}`)
     await rwClient.v2.tweet(message, tweetOpts)
   } catch (err) {
-    action_core.setFailed(`Action failed with error. ${err} ${err.data ?? ''}`.trim())
+    action_core.setFailed(
+      `Action failed with error. ${err} ${
+        JSON.stringify(err.data) ?? ''
+      }`.trim()
+    )
   } finally {
     action_core.info(`
       *** ACTION RUN - END ***
@@ -34769,7 +35107,9 @@ async function uploadMedia(client, media, mediaAltText) {
       )
     } catch (err) {
       action_core.warning(
-        `Twitter createMediaMetadata - Failed. ${err} ${err.data ?? ''}`.trim()
+        `Twitter createMediaMetadata - Failed. ${err} ${
+          JSON.stringify(err.data) ?? ''
+        }`.trim()
       )
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11313,7 +11313,7 @@
     "actions-toolkit": {
       "version": "git+ssh://git@github.com/nearform/actions-toolkit.git#e206336e409b4d9ae2832aae3e0b4aa76cdc5f0c",
       "integrity": "sha512-l4XKpABkFz8TvmhtKZ7SuB57YnbA5mkNaujJaQWnwaKe5S4wbjHo6bxaEffkKVoCfNsAwZUotLZFAIDALJ74Gw==",
-      "from": "actions-toolkit@github:nearform/actions-toolkit#e206336e409b4d9ae2832aae3e0b4aa76cdc5f0c",
+      "from": "actions-toolkit@github:nearform/actions-toolkit",
       "requires": {
         "@actions/core": "^1.11.1"
       }

--- a/src/action.js
+++ b/src/action.js
@@ -57,7 +57,11 @@ export async function run() {
       tweetOpts.media = { media_ids }
     }
   } catch (err) {
-    core.setFailed(`Action failed with error. ${err} ${err.data ?? ''}`.trim())
+    core.setFailed(
+      `Action failed with error. ${err} ${
+        JSON.stringify(err.data) ?? ''
+      }`.trim()
+    )
     core.info(`
       *** ACTION RUN - END ***
       `)
@@ -68,7 +72,11 @@ export async function run() {
     core.info(`Twitter message: ${message}`)
     await rwClient.v2.tweet(message, tweetOpts)
   } catch (err) {
-    core.setFailed(`Action failed with error. ${err} ${err.data ?? ''}`.trim())
+    core.setFailed(
+      `Action failed with error. ${err} ${
+        JSON.stringify(err.data) ?? ''
+      }`.trim()
+    )
   } finally {
     core.info(`
       *** ACTION RUN - END ***
@@ -100,7 +108,9 @@ export async function uploadMedia(client, media, mediaAltText) {
       )
     } catch (err) {
       core.warning(
-        `Twitter createMediaMetadata - Failed. ${err} ${err.data ?? ''}`.trim()
+        `Twitter createMediaMetadata - Failed. ${err} ${
+          JSON.stringify(err.data) ?? ''
+        }`.trim()
       )
     }
   }


### PR DESCRIPTION
This PR Fixes https://github.com/nearform-actions/github-action-notify-twitter/issues/598 by stringifying the err.data object in 3 catch blocks.

3 test cases were added to test these conditions, but note that the errors in the tests are invented and may not be real error messages.

Other Notes:

- the `package-lock.json` file was updated when I did `npm install`, let me know if you want those changes reverted
- I had to disable the husky directory otherwise git would not allow me to make the commit. I believe that was due to different line endings on Windows which are corrected during the commit process. I'm not 100% sure that's the case as the error message was not clear. It might be worth adding a `.gitattributes` file if you are always needing `LF` line endings for your linting and everything to work properly. I ran the lint and build locally before commiting and believe everything is good, but please double check.